### PR TITLE
Enable testing of extensions to narra_core

### DIFF
--- a/lib/narra/core/engine.rb
+++ b/lib/narra/core/engine.rb
@@ -20,6 +20,7 @@
 #
 
 require 'narra/core'
+require 'rails/all'
 
 module Narra
   module Core

--- a/lib/narra/tools/defaults_hash.rb
+++ b/lib/narra/tools/defaults_hash.rb
@@ -19,9 +19,11 @@
 # Authors: Michal Mocnak <michal@marigan.net>, Krystof Pesek <krystof.pesek@gmail.com>
 #
 
+require 'active_support/all'
+
 module Narra
   module Tools
-    class DefaultsHash < ActiveSupport::HashWithIndifferentAccess
+    class DefaultsHash < ::ActiveSupport::HashWithIndifferentAccess
       def []=(key, val)
         # persist if there is no already
         if Narra::Tools::Settings.get(convert_key(key)).nil?


### PR DESCRIPTION
Change of basic core libraries to require dependencies before using them.
All plugins to narra (i.e. narra-youtube) should only require 'narra/core' now.